### PR TITLE
Fixed send packet description

### DIFF
--- a/router.py
+++ b/router.py
@@ -12,7 +12,6 @@ class Router(Device):
         Device.__init__(self, identifier)
 
     # Called internally by routers to forward packets
-    # and called externally by flows to initiate packet sending
     def send_packet(self, packet):
         # Get packet destination from packet and decide
         # where to send packet next


### PR DESCRIPTION
Fixed the router class send_packet function comment to specify that  the
method should only be called by the self router
