### PR TITLE
Fix RTT graph.

### DIFF
--- a/flow.py
+++ b/flow.py
@@ -22,7 +22,7 @@ class Flow:
         self.destination = destination
         self.amount = amount
         self.total = amount
-        self.start_time = start_time * 1000;
+        self.start_time = start_time;
         self.event_scheduler = None
         self.logger = None
         self.complete = False

--- a/link.py
+++ b/link.py
@@ -63,7 +63,7 @@ class Link:
 
     def __str__(self):
         return ("Link ID   " + self.identifier + "\n"
-                "rate:     " + str(self.rate) + " mbps\n"
+                "rate:     " + str(self.rate) + " bytes/s\n"
                 "delay:    " + str(self.delay) + " ms\n"
                 "buffer:   " + str(self.buffer.available_space) + " bytes\n"
                 "device A: " + self.deviceA.identifier + "\n"

--- a/parsing.py
+++ b/parsing.py
@@ -49,7 +49,7 @@ def generate_simulation_from_testcase(input_dict):
         source = hosts.get(source_id)
         destination = hosts.get(destination_id)
         controller = CongestionControllerReno()
-        flow = Flow(f["id"], source, destination, f["amount"] * BYTES_PER_MEGABYTE, f["start"], controller)
+        flow = Flow(f["id"], source, destination, f["amount"] * BYTES_PER_MEGABYTE, f["start"] * 1000, controller)
         controller.flow = flow
         flows[f["id"]] = flow
         source.flows[f["id"]] = flow


### PR DESCRIPTION
The new implementation simply counts the RTT as the time between when
an identifier was first sent and the time when its acknowledgement was
finally received.
